### PR TITLE
replace any NA with 0 in sel.gr$score 

### DIFF
--- a/R/PTscore.R
+++ b/R/PTscore.R
@@ -59,6 +59,9 @@ PTscore <- function(obj, txs,
   sel.gr <- unlist(sel.gr)
   sel.gr$score <- unlist(vms)
   
+  # sets any NAN values equal to zero
+  sel.gr$score[is.na(sel.gr$score)] <- 0
+
   pro <- sel.gr[sel.gr$source %in% "promoter"]
   body <- sel.gr[sel.gr$source %in% "transcript"]
   stopifnot(identical(pro$oid, body$oid))


### PR DESCRIPTION
While using this function I encountered a situation where 5 'NA' values were a part of the vector sel.gr$score, causing the the evaluation of `smallNumber <- max(c(1e-6, min(pro$score), min(body$score)))` to return NA, breaking the calculation of `sel$log2meanCoverage`, and `sel$PT_score`. Here is a simple fix. 