### PR TITLE
Fix wrong index assgined in gal1

### DIFF
--- a/R/shiftGAlignmentsList.R
+++ b/R/shiftGAlignmentsList.R
@@ -74,6 +74,7 @@ shiftGAlignmentsList <- function(gal, positive=4L, negative=5L, outbam){
                   to=paste0(outbam, ".bai"))
         gal1 <- GAlignments()
         meta$file <- outbam
+        meta$index <- outbam
         meta$asMates <- FALSE
         meta$mpos <- mpos
         metadata(gal1) <- meta

--- a/R/splitBam.R
+++ b/R/splitBam.R
@@ -2,8 +2,6 @@
 #' @description shift the bam files by 5'ends and split the bam files.
 #' @param bamfile character(1). File name of bam.
 #' @param tags A vector of characters indicates the tags in bam file.
-#' @param index The names of the index file of the 'BAM' file being processed;
-#'        This is given without the '.bai' extension.
 #' @param outPath Output file path.
 #' @param txs \link[GenomicRanges:GRanges-class]{GRanges} of transcripts.
 #' @param genome An object of \link[BSgenome:BSgenome-class]{BSgenome}
@@ -41,7 +39,7 @@
 #'                  seqlev="chr1")
 #'}
 
-splitBam <- function(bamfile, tags, index=bamfile, outPath=NULL,
+splitBam <- function(bamfile, tags, outPath=NULL,
                      txs, genome, conservation,
                      positive=4L, negative=5L,
                      breaks=c(0, 100, 180, 247, 315, 473, 558, 615, Inf),
@@ -89,7 +87,7 @@ splitBam <- function(bamfile, tags, index=bamfile, outPath=NULL,
 
   ## shift
   which <- as(seqinfo(genome)[seqlev], "GRanges")
-  gal <- readBamFile(bamfile, index=index, tag=tags, which=which, 
+  gal <- readBamFile(bamfile, tag=tags, which=which, 
                      what=c("qname", "flag", "mapq", "isize", 
                             "seq", "qual", "mrnm"),
                      flag=flag,


### PR DESCRIPTION
Originally `splitBam` will take bamfile index and pass it to `shiftGAlignmentsList` and `splitGAlignmentsByCut`. Because `meta$index` is not empty, the wrong index (for the original bam) will get store into gal1 which has `shifted.bam` assgined to `meta$file` but not `shifted.bam` to its `meta$index`. Then `splitGAlignmentsByCut` halted with below error message:
> Error in splitGAlignmentsByCut(gal1, breaks = breaks, labels = labels,  : 
>   no reads in the obj.

By removing index param from `splitBam`, both `shiftGAlignmentsList` and `splitGAlignmentsByCut` will get the index from the `ifelse` from the respective `meta$file`

`index <- ifelse(length(meta$index)>0, meta$index, meta$file)`

Additionally, a line to include the bam index in gal1 was added in `shiftGAlignmentsList.R` to complete the metadata of gal1
