### PR TITLE
Clear loaded tracks in IGVSnapshot.R

### DIFF
--- a/inst/extdata/IGVSnapshot.R
+++ b/inst/extdata/IGVSnapshot.R
@@ -98,7 +98,7 @@ IGVSnapshot <- function(maxMem, genomeBuild="hg38", bamFileFullPathOrURLs,
       SRAdb::IGVsession(files=bamFileFullPathOrURLs, sessionFile=sessionFile, 
                    genome=genomeBuild, VisibleAttribute='', destdir=outDir)
     }
-    
+    SRAdb::IGVclear(sock)
 }
 
 #### Helper function: interactively get geneNames or genomicRegions from standard input, 


### PR DESCRIPTION
Added a function to clear loaded tracks after each run of `IGVSnapshot()` without restart IGV. Otherwise previous tracks at the same gene/genomic location will keep stacking over tracks loaded later.